### PR TITLE
Add CyanogenMod build environment files for more compatibility

### DIFF
--- a/cm.dependencies
+++ b/cm.dependencies
@@ -1,0 +1,6 @@
+[
+ {
+   "repository": "android_kernel_lge_hammerhead",
+   "target_path": "kernel/lge/hammerhead"
+ }
+]

--- a/cm.mk
+++ b/cm.mk
@@ -1,0 +1,25 @@
+# Boot animation
+TARGET_SCREEN_HEIGHT := 1920
+TARGET_SCREEN_WIDTH := 1080
+TARGET_BOOTANIMATION_HALF_RES := true
+
+# Inherit some common CM stuff.
+$(call inherit-product, vendor/cm/config/common_full_phone.mk)
+
+# Enhanced NFC
+$(call inherit-product, vendor/cm/config/nfc_enhanced.mk)
+
+# Inherit device configuration
+$(call inherit-product, device/lge/hammerhead/full_hammerhead.mk)
+
+## Device identifier. This must come after all inclusions
+PRODUCT_DEVICE := hammerhead
+PRODUCT_NAME := cm_hammerhead
+PRODUCT_BRAND := google
+PRODUCT_MODEL := Nexus 5
+PRODUCT_MANUFACTURER := LGE
+
+PRODUCT_BUILD_PROP_OVERRIDES += \
+    PRODUCT_NAME=hammerhead \
+    BUILD_FINGERPRINT=google/hammerhead/hammerhead:6.0.1/MOB30Y/3067468:user/release-keys \
+    PRIVATE_BUILD_DESC="hammerhead-user 6.0.1 MOB30Y 3067468 release-keys"


### PR DESCRIPTION
Mostly for convenience when building CM making the device tree universal, hopefully I didn't forget another file or two.
